### PR TITLE
issue#7 : Downgrade compile target to java-7 for compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,36 @@
 	<build>
 		<plugins>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5.1</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>animal-sniffer-maven-plugin</artifactId>
+				<version>1.15</version>
+				<configuration>
+					<signature>
+						<groupId>org.codehaus.mojo.signature</groupId>
+						<artifactId>java17</artifactId>
+						<version>1.0</version>
+					</signature>
+				</configuration>
+				<executions>
+					<execution>
+						<id>check-jvm-compliance</id>
+						<phase>test</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>properties-maven-plugin</artifactId>
 				<version>1.0-alpha-2</version>


### PR DESCRIPTION
The compile target was inherited from the parent pom to be java-8, but there are no java-8 features used here so it could be java-7 instead. Added the source/target for java-7 along with animal-sniffer-maven-plugin to verify that it doesn't use any java-8 APIs in future unless the animal sniffer maven plugin signatures are also updated to java8/java9/etc.

Fixes issue#7
