### PR TITLE
Added option to select wildcard rule

### DIFF
--- a/src/main/java/de/malkusch/whoisServerList/publicSuffixList/PublicSuffixListFactory.java
+++ b/src/main/java/de/malkusch/whoisServerList/publicSuffixList/PublicSuffixListFactory.java
@@ -63,6 +63,11 @@ public final class PublicSuffixListFactory {
     public static final String PROPERTY_INDEX_FACTORY = "psl.indexFactory";
 
     /**
+     * Use wildcard rule.
+     */
+    public static final String PROPERTY_USE_WILDCARD = "psl.use.wildcard";
+
+    /**
      * Location of the default properties.
      *
      * @see #build()
@@ -124,7 +129,7 @@ public final class PublicSuffixListFactory {
 
     /**
      * Builds a PublicSuffixList.
-     * 
+     *
      * @param list
      *            The list.
      * @return a public suffix list
@@ -142,7 +147,7 @@ public final class PublicSuffixListFactory {
 
     /**
      * Downloads the public suffix list.
-     * 
+     *
      * @return a public suffix list
      * @throws IOException
      *             If the list can't be downloaded.
@@ -168,12 +173,12 @@ public final class PublicSuffixListFactory {
 
     /**
      * Builds a PublicSuffixList.
-     * 
+     *
      * @param list
      *            The list.
      * @return a public suffix list
      */
-    private PublicSuffixList build(InputStream list, Properties properties)
+    public PublicSuffixList build(InputStream list, Properties properties)
             throws IOException, ClassNotFoundException, InstantiationException, IllegalAccessException {
         URL url = new URL(properties.getProperty(PROPERTY_URL));
 
@@ -181,12 +186,14 @@ public final class PublicSuffixListFactory {
 
         IndexFactory indexFactory = loadIndexFactory(properties.getProperty(PROPERTY_INDEX_FACTORY));
 
-        return build(list, url, charset, indexFactory);
+        boolean useDefaultRule = Boolean.parseBoolean(properties.getProperty(PROPERTY_USE_WILDCARD));
+
+        return build(list, url, charset, indexFactory, useDefaultRule);
     }
 
     /**
      * Loads the index factory.
-     * 
+     *
      * @param indexFactoryClassName
      *            the class name of the index factory.
      * @return the index factory
@@ -218,7 +225,7 @@ public final class PublicSuffixListFactory {
 
     /**
      * Builds a PublicSuffixList.
-     * 
+     *
      * @param list
      *            The list.
      * @param url
@@ -233,12 +240,14 @@ public final class PublicSuffixListFactory {
      *             The list could not be read.
      */
     private PublicSuffixList build(final InputStream list, final URL url, final Charset charset,
-            final IndexFactory indexFactory) throws IOException {
+                                   final IndexFactory indexFactory, boolean useDefaultRule) throws IOException {
         Parser parser = new Parser();
         List<Rule> rules = parser.parse(list, charset);
 
         // add default rule
-        rules.add(Rule.DEFAULT);
+        if (useDefaultRule) {
+            rules.add(Rule.DEFAULT);
+        }
 
         Index index = indexFactory.build(rules);
 

--- a/src/main/resources/psl.properties
+++ b/src/main/resources/psl.properties
@@ -2,3 +2,4 @@ psl.url = https://publicsuffix.org/list/effective_tld_names.dat
 psl.file = /effective_tld_names.dat
 psl.charset = UTF-8
 psl.indexFactory = de.malkusch.whoisServerList.publicSuffixList.index.tree.TreeIndexFactory
+psl.use.wildcard = true

--- a/src/test/java/de/malkusch/whoisServerList/publicSuffixList/ExampleTest.java
+++ b/src/test/java/de/malkusch/whoisServerList/publicSuffixList/ExampleTest.java
@@ -3,6 +3,7 @@ package de.malkusch.whoisServerList.publicSuffixList;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.util.Properties;
 
 import org.junit.Test;
 
@@ -34,6 +35,24 @@ public class ExampleTest {
 
         assertEquals("食狮.com.cn", suffixList.getRegistrableDomain("食狮.com.cn"));
         assertEquals("xn--85x722f.com.cn", suffixList.getRegistrableDomain("xn--85x722f.com.cn"));
+    }
+
+    @Test
+    public void testExampleWithoutWildcardRule() throws IOException, ClassNotFoundException {
+        PublicSuffixListFactory factory = new PublicSuffixListFactory();
+        Properties properties = factory.getDefaults();
+        properties.setProperty("psl.use.wildcard", "false");
+        PublicSuffixList suffixList = factory.build(properties);
+
+        assertTrue(suffixList.isPublicSuffix("net"));
+        assertFalse(suffixList.isPublicSuffix("bad"));
+
+        assertNull(suffixList.getRegistrableDomain("net"));
+        assertNull(suffixList.getRegistrableDomain("example.example"));
+        assertNull(suffixList.getRegistrableDomain("bad.bad"));
+        assertEquals("example.net", suffixList.getRegistrableDomain("www.example.net"));
+        assertEquals("example.co.uk", suffixList.getRegistrableDomain("example.co.uk"));
+        assertEquals("example.co.uk", suffixList.getRegistrableDomain("www.example.co.uk"));
     }
 
 }


### PR DESCRIPTION
Similar issue with https://github.com/whois-server-list/public-suffix-list/issues/9. I ran into a problem when I don't need wildcard rule and want to get real existing suffix. I added property for this, and it should not affect the existing logic in any way, just add a little flexibility. I would be grateful if you consider this PR.